### PR TITLE
🔧: コンテンツレイヤーによるtailwindcssが当たら なくなる事案を多分解決

### DIFF
--- a/post-writer-webapp/package-lock.json
+++ b/post-writer-webapp/package-lock.json
@@ -28,11 +28,11 @@
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
-        "autoprefixer": "^10.4.16",
+        "autoprefixer": "^10.4.21",
         "eslint": "^8",
         "eslint-config-next": "13.5.4",
-        "postcss": "^8.4.31",
-        "tailwindcss": "^3.3.0",
+        "postcss": "^8.5.3",
+        "tailwindcss": "^3.4.17",
         "typescript": "^5"
       }
     },

--- a/post-writer-webapp/package.json
+++ b/post-writer-webapp/package.json
@@ -29,11 +29,11 @@
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "autoprefixer": "^10.4.16",
+    "autoprefixer": "^10.4.21",
     "eslint": "^8",
     "eslint-config-next": "13.5.4",
-    "postcss": "^8.4.31",
-    "tailwindcss": "^3.3.0",
+    "postcss": "^8.5.3",
+    "tailwindcss": "^3.4.17",
     "typescript": "^5"
   }
 }

--- a/post-writer-webapp/postcss.config.js
+++ b/post-writer-webapp/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/post-writer-webapp/postcss.config.mjs
+++ b/post-writer-webapp/postcss.config.mjs
@@ -1,5 +1,0 @@
-const config = {
-  plugins: ["@tailwindcss/postcss"],
-};
-
-export default config;


### PR DESCRIPTION
## コンテンツレイヤーによるtailwindcssが当たら なくなる事案を多分解決

tailwincss を 再インストール

( https://v3.tailwindcss.com/docs/guides/nextjs )

tailwindcss.config.mjs を削除し、tailwindcss.config.js を採用